### PR TITLE
Role zabbix crud

### DIFF
--- a/docs/ZABBIX_CRUD_ROLE.md
+++ b/docs/ZABBIX_CRUD_ROLE.md
@@ -1,15 +1,4 @@
-# community.zabbix.zabbix_proxy role
-
-**Table of Contents**
-
-- [Overview](#overview)
-  * [Zabbix Versions](#zabbix-versions)
-- [Role Variables](#role-variables)
-  * [Main variables](#main-variables)
-  * [Zabbix API variables](#zabbix-api-variables)
-- [Example Playbook](#example-playbook)
-- [License](#license)
-- [Author Information](#author-information)
+# community.zabbix.zabbix_crud role
 
 # Overview
 

--- a/docs/ZABBIX_CRUD_ROLE.md
+++ b/docs/ZABBIX_CRUD_ROLE.md
@@ -38,13 +38,13 @@ See `defaults/main.yml` for more details.
 
 ## Zabbix API connection variables
 
-`zabbix_crud_httpapi_port`: connection httpapi port, `80` by default.
-`zabbix_crud_httpapi_use_ssl`: use SSL for httpapi connection, `false` by default.
-`zabbix_crud_httpapi_validate_certs`: validate certs for httpapi connection, `false` by default.
-`zabbix_crud_zabbix_url_path`: path to web directory or alias, `zabbix` by default.
-`zabbix_crud_login_user`: login user, `Admin` by default.
-`zabbix_crud_login_password`: login password, `zabbix` by default.
-`zabbix_crud_auth_key`: API token for access. Not set by default.
+`zabbix_api_server_port`: connection httpapi port, `80` by default.
+`zabbix_api_use_ssl`: use SSL for httpapi connection, `false` by default.
+`zabbix_api_validate_certs`: validate certs for httpapi connection, `false` by default.
+`zabbix_api_zabbix_url_path`: path to web directory or alias, `zabbix` by default.
+`zabbix_api_http_user`: login user, `Admin` by default.
+`zabbix_api_http_password`: login password, `zabbix` by default.
+`zabbix_api_auth_key`: API token for access. Not set by default.
 
 # Example Playbook
 

--- a/docs/ZABBIX_CRUD_ROLE.md
+++ b/docs/ZABBIX_CRUD_ROLE.md
@@ -1,7 +1,5 @@
 # community.zabbix.zabbix_proxy role
 
-![Zabbix Proxy](https://github.com/ansible-collections/community.zabbix/workflows/community.zabbix.zabbix_proxy/badge.svg)
-
 **Table of Contents**
 
 - [Overview](#overview)

--- a/docs/ZABBIX_CRUD_ROLE.md
+++ b/docs/ZABBIX_CRUD_ROLE.md
@@ -1,0 +1,72 @@
+# community.zabbix.zabbix_proxy role
+
+![Zabbix Proxy](https://github.com/ansible-collections/community.zabbix/workflows/community.zabbix.zabbix_proxy/badge.svg)
+
+**Table of Contents**
+
+- [Overview](#overview)
+  * [Zabbix Versions](#zabbix-versions)
+- [Role Variables](#role-variables)
+  * [Main variables](#main-variables)
+  * [Zabbix API variables](#zabbix-api-variables)
+- [Example Playbook](#example-playbook)
+- [License](#license)
+- [Author Information](#author-information)
+
+# Overview
+
+This role performs several CRUD actions vía Zabbix API. Takes most common modules, wrap in to variables and configure it.
+
+Supported modules:
+- [zabbix_mediatype](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_mediatype_module.html#ansible-collections-community-zabbix-zabbix-mediatype-module)
+- [zabbix_usergroup](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_usergroup_module.html#ansible-collections-community-zabbix-zabbix-usergroup-module)
+- [zabbix_user_role](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_role_module.html#ansible-collections-community-zabbix-zabbix-user-role-module)
+- [zabbix_user](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_module.html#ansible-collections-community-zabbix-zabbix-user-module)
+- [zabbix_group](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_group_module.html#ansible-collections-community-zabbix-zabbix-group-module)
+- [zabbix_template](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_template_module.html#ansible-collections-community-zabbix-zabbix-template-module)
+- [zabbix_host](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_module.html#ansible-collections-community-zabbix-zabbix-host-module)
+- [zabbix_script](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_script_module.html#ansible-collections-community-zabbix-zabbix-script-module)
+- [zabbix_action](https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_action_module.html#ansible-collections-community-zabbix-zabbix-action-module)
+
+# Requirements
+
+## Ansible 2.10 and higher
+
+# Role Variables
+
+## Main variables
+
+See `defaults/main.yml` for more details.
+
+## Zabbix API connection variables
+
+`zabbix_crud_httpapi_port`: connection httpapi port, `80` by default.
+`zabbix_crud_httpapi_use_ssl`: use SSL for httpapi connection, `false` by default.
+`zabbix_crud_httpapi_validate_certs`: validate certs for httpapi connection, `false` by default.
+`zabbix_crud_zabbix_url_path`: path to web directory or alias, `zabbix` by default.
+`zabbix_crud_login_user`: login user, `Admin` by default.
+`zabbix_crud_login_password`: login password, `zabbix` by default.
+`zabbix_crud_auth_key`: API token for access. Not set by default.
+
+# Example Playbook
+
+Including an example of how to use your role (for instance, with variables passed in as parameters) is always nice for users too:
+
+```yaml
+  - hosts: zabbix-server
+    roles:
+      - role: community.zabbix.zabbix_crud
+```
+
+# License
+
+GNU General Public License v3.0 or later
+
+See LICENCE to see the full text.
+
+# Author Information
+
+Please send suggestion or pull requests to make this role better. Also let us know if you encounter any issues installing or using this role.
+
+Github: https://github.com/ansible-collections/community.zabbix
+

--- a/roles/zabbix_crud/README.md
+++ b/roles/zabbix_crud/README.md
@@ -1,0 +1,1 @@
+../../docs/ZABBIX_CRUD_ROLE.md

--- a/roles/zabbix_crud/defaults/main.yml
+++ b/roles/zabbix_crud/defaults/main.yml
@@ -3,13 +3,17 @@
 
 # Defaults vars to connect via API:
 zabbix_api_server_port: 80
+zabbix_api_url_path: 'zabbix'
 zabbix_api_use_ssl: false
 zabbix_api_validate_certs: false
-zabbix_api_url_path: 'zabbix'
-zabbix_api_http_user: "Admin"
-zabbix_api_http_password: "zabbix"
-# zabbix_api_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
+zabbix_api_http_user: Admin
+zabbix_api_http_password: !unsafe zabbix
+# zabbix_api_auth_key: a_previously_generated_token
 
+
+zabbix_crud_host_groups: []
+  # - host_group: "Web Servers"
+  #   state: absent # or present
 
 zabbix_crud_mediatypes: []
   # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_mediatype_module.html#ansible-collections-community-zabbix-zabbix-mediatype-module
@@ -47,7 +51,7 @@ zabbix_crud_mediatypes: []
   #   webhook_script:
   #   webhook_timeout:
 
-zabbix_crud_zabbix_usergroups: []
+zabbix_crud_usergroups: []
   # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_usergroup_module.html#ansible-collections-community-zabbix-zabbix-usergroup-module
   # - name: operators
   #   debug_mode:
@@ -80,7 +84,7 @@ zabbix_crud_user_roles: []
   #   type: "User" # by default. Options: User | Admin | Super Admin
   #   rules: [] # details: https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
 
-zabbix_crud_zabbix_users: []
+zabbix_crud_users: []
   # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_module.html#ansible-collections-community-zabbix-zabbix-user-module
   # - username: jperez
   #   usrgrps:
@@ -103,15 +107,12 @@ zabbix_crud_zabbix_users: []
   #   user_medias:
   #     - { mediatype: Help Desk, sendto: juan.perez@my_domain.org }
 
-zabbix_crud_host_groups: []
-  # - host_group: "Web Servers"
-  #   state: absent # or present
 
-zabbix_crud_templates: []
+zabbix_crud_json_templates: []
   # # JSON files to import:
   # - "{{ playbook_dir }}/files/zabbix_crud/json_templates/Linux_by_zabbix_agent_activ.json"
 
-zabbix_crud_zabbix_hosts: []
+zabbix_crud_hosts: []
   # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_module.html#ansible-collections-community-zabbix-zabbix-host-module
   # - host_name: hostname
   #   visible_name: Visible Name

--- a/roles/zabbix_crud/defaults/main.yml
+++ b/roles/zabbix_crud/defaults/main.yml
@@ -1,0 +1,202 @@
+---
+# defaults file for zabbix_crud
+
+# Defaults vars to connect via API:
+zabbix_crud_httpapi_port: 80
+zabbix_crud_httpapi_use_ssl: false
+zabbix_crud_httpapi_validate_certs: false
+zabbix_crud_zabbix_url_path: 'zabbix'
+zabbix_crud_login_user: "Admin"
+zabbix_crud_login_password: "zabbix"
+# zabbix_crud_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
+
+
+zabbix_crud_mediatypes: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_mediatype_module.html#ansible-collections-community-zabbix-zabbix-mediatype-module
+  # - name: Help Desk
+  #   type: email # Options: email | script | sms | webhook | jabber | ez_texting
+  #   attempt_interval:
+  #   description: "Help desk team"
+  #   event_menu:
+  #   event_menu_name:
+  #   event_menu_url:
+  #   gsm_modem:
+  #   max_attempts:
+  #   max_sessions:
+  #   message_templates:
+  #     - { body: "Problem started at {EVENT.TIME} on {EVENT.DATE}\r\nProblem name: {EVENT.NAME}\r\n", eventsource: triggers, recovery: operations, subject: "Problem: {EVENT.NAME}" }
+  #   message_text_limit:
+  #   password:
+  #   process_tags:
+  #   script_name:
+  #   script_params:
+  #   smtp_authentication: true # or false
+  #   smtp_email: zabbix@my_domain.org
+  #   smtp_helo: ""
+  #   smtp_security: none # Options: none | STARTTLS | SSL/TLS
+  #   smtp_server: mail.my_domain.org
+  #   smtp_server_port:
+  #   smtp_verify_host: true # or false
+  #   smtp_verify_peer: true # or false
+  #   state:
+  #   status:
+  #   username:
+  #   password:
+  #   webhook_params:
+  #     - {name: alert_message, value: "{ALERT_MESSAGE}"}
+  #   webhook_script:
+  #   webhook_timeout:
+
+zabbix_crud_zabbix_usergroups: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_usergroup_module.html#ansible-collections-community-zabbix-zabbix-usergroup-module
+  # - name: operators
+  #   debug_mode:
+  #   gui_access: "disable" # "disable" | "default" | "internal" | "LDAP"
+  #   hostgroup_rights: # for zabbix >= 6
+  #     - host_group: "Web Servers"
+  #       permission: "read-only"
+  #     - host_group: "Hipervisors"
+  #       permission: "read-write"
+  #     - host_group: "Linux Servers"
+  #       permission: "denied"
+  #   rights:  # for zabbix <= 6
+  #     - host_group: "Web Servers"
+  #       permission: "read-only"
+  #     - host_group: "Hipervisors"
+  #       permission: "read-write"
+  #     - host_group: "Linux Servers"
+  #       permission: "denied"
+  #   state: absent # or present
+  #   status:
+  #   tag_filters:
+  #     - host_group: "Web Servers"
+  #       tag: ""
+  #       value: ""
+
+zabbix_crud_user_roles: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_role_module.html#ansible-collections-community-zabbix-zabbix-user-role-module
+  # - name: TI Operator
+  #   state: present # by default. Or absent
+  #   type: "User" # by default. Options: User | Admin | Super Admin
+  #   rules: [] # details: https://www.zabbix.com/documentation/current/en/manual/api/reference/role/object#role-rules
+
+zabbix_crud_zabbix_users: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_user_module.html#ansible-collections-community-zabbix-zabbix-user-module
+  # - username: jperez
+  #   usrgrps:
+  #     - "operators"  #   type: "Zabbix super admin" # "Zabbix super admin" | "Zabbix user" | "Zabbix admin"
+  #   after_login_url:
+  #   autologin:
+  #   autologout:
+  #   current_password:
+  #   lang:
+  #   name: Juan
+  #   override_passwd: yes # or no
+  #   passwd: "super-secret-pass"
+  #   refresh:
+  #   role_name: "User role" # By default: "User role" | "Admin role" | "Guest role" | "Super admin role"
+  #   rows_per_page:
+  #   state: "present" # "present" by default or "absent"
+  #   surname: Perez
+  #   theme:
+  #   timezone:
+  #   user_medias:
+  #     - { mediatype: Help Desk, sendto: juan.perez@my_domain.org }
+
+zabbix_crud_host_groups: []
+  # - host_group: "Web Servers"
+  #   state: absent # or present
+
+zabbix_crud_templates: []
+  # # JSON files to import:
+  # - "{{ playbook_dir }}/files/zabbix_crud/json_templates/Linux_by_zabbix_agent_activ.json"
+
+zabbix_crud_zabbix_hosts: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_host_module.html#ansible-collections-community-zabbix-zabbix-host-module
+  # - host_name: hostname
+  #   visible_name: Visible Name
+  #   ca_cert:
+  #   tls_accept:
+  #   tls_connect:
+  #   tls_psk:
+  #   tls_psk_identity:
+  #   tls_subject:
+  #   description: Description
+  #   host_groups: Host groups
+  #   link_templates:
+  #     - Linux by Zabbix agent
+  #   status: enabled
+  #   state: present
+  #   proxy: my_proxy
+  #   macros:
+  #     - macro: '{$MY_MACRO}'
+  #       value: my_value
+  #     - macro: '{$MY_SECRET_MACRO}'
+  #       value: "{{ vault_my_secret_macro }}"
+  #       type: secret
+  #   interfaces:
+  #     - ip: "{{ ansible_host }}"
+  #       type: snmp # valores: agent, 1, snmp, 2, ipmi, 3, jmx, 4
+  #       useip: 1
+  #       dns: ""
+  #       main: 1
+  #       port: 161
+  #       details:
+  #         version: 3 # SNMP version, values: 1, 2 o 3
+  #         securitylevel: 2 # Options: 0 (noAuthNoPriv), 1 (authNoPriv), 2 (authPriv)
+  #         authprotocol: 1 # Options: 0 (MD5), 1 (SHA)
+  #         authpassphrase: '{$AUTHPASSPHRASE}'
+  #         privprotocol: 1 # Options: 0 (DES), 1 (AES)
+  #         privpassphrase: '{$PRIVPASSPHRASE}'
+  #         securityname: "snmp_user"
+  #         contextname: ""
+  #   tags:
+  #     - { tag: , value:  }
+  #   force:
+  #   inventory_mode:
+  #   inventory_zabbix:
+  #   ipmi_authtype:
+  #   ipmi_password:
+  #   ipmi_privilege:
+  #   ipmi_username:
+
+zabbix_crud_scripts: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_script_module.html#ansible-collections-community-zabbix-zabbix-script-module
+  # - name: Example script
+  #   command: "return 0"
+  #   script_type: webhook # Options: script | ipmi | ssh | telnet | webhook
+  #   authtype:
+  #   confirmation:
+  #   description:
+  #   execute_on:
+  #   host_access:
+  #   host_group:
+  #   menu_path:
+  #   parameters:
+  #   password:
+  #   port:
+  #   privatekey:
+  #   publickey:
+  #   scope:
+  #   script_timeout:
+  #   state:
+  #   user_group:
+  #   username:
+
+zabbix_crud_actions: []
+  # # For details: https://docs.ansible.com/ansible/latest/collections/community/zabbix/zabbix_action_module.html#ansible-collections-community-zabbix-zabbix-action-module
+  # - name: Alert TI team
+  #   acknowledge_operations: []
+  #   conditions: []
+  #   esc_period:
+  #   eval_type:
+  #   event_source:
+  #   formula:
+  #   notify_if_canceled:
+  #   operations: []
+  #   pause_in_maintenance:
+  #   pause_symptoms:
+  #   recovery_operations: []
+  #   state:
+  #   status:
+

--- a/roles/zabbix_crud/defaults/main.yml
+++ b/roles/zabbix_crud/defaults/main.yml
@@ -2,13 +2,13 @@
 # defaults file for zabbix_crud
 
 # Defaults vars to connect via API:
-zabbix_crud_httpapi_port: 80
-zabbix_crud_httpapi_use_ssl: false
-zabbix_crud_httpapi_validate_certs: false
-zabbix_crud_zabbix_url_path: 'zabbix'
-zabbix_crud_login_user: "Admin"
-zabbix_crud_login_password: "zabbix"
-# zabbix_crud_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
+zabbix_api_server_port: 80
+zabbix_api_use_ssl: false
+zabbix_api_validate_certs: false
+zabbix_api_url_path: 'zabbix'
+zabbix_api_http_user: "Admin"
+zabbix_api_http_password: "zabbix"
+# zabbix_api_auth_key: 8ec0d52432c15c91fcafe9888500cf9a607f44091ab554dbee860f6b44fac895
 
 
 zabbix_crud_mediatypes: []

--- a/roles/zabbix_crud/handlers/main.yml
+++ b/roles/zabbix_crud/handlers/main.yml
@@ -1,0 +1,2 @@
+---
+# handlers file for zabbix_crud

--- a/roles/zabbix_crud/meta/main.yml
+++ b/roles/zabbix_crud/meta/main.yml
@@ -1,0 +1,52 @@
+galaxy_info:
+  author: Victor Alem
+  description: Several features to create/read/update/delete (CRUD) data vía Zabbix API
+  company: LibreDevOps
+
+  # If the issue tracker for your role is not on github, uncomment the
+  # next line and provide a value
+  # issue_tracker_url: http://example.com/issue/tracker
+
+  # Choose a valid license ID from https://spdx.org - some suggested licenses:
+  # - BSD-3-Clause (default)
+  # - MIT
+  # - GPL-2.0-or-later
+  # - GPL-3.0-only
+  # - Apache-2.0
+  # - CC-BY-4.0
+  license: GPL-2.0-or-later
+
+  min_ansible_version: 2.13
+
+  # If this a Container Enabled role, provide the minimum Ansible Container version.
+  # min_ansible_container_version:
+
+  #
+  # Provide a list of supported platforms, and for each platform a list of versions.
+  # If you don't wish to enumerate all versions for a particular platform, use 'all'.
+  # To view available platforms and versions (or releases), visit:
+  # https://galaxy.ansible.com/api/v1/platforms/
+  #
+  # platforms:
+  # - name: Fedora
+  #   versions:
+  #   - all
+  #   - 25
+  # - name: SomePlatform
+  #   versions:
+  #   - all
+  #   - 1.0
+  #   - 7
+  #   - 99.99
+
+  galaxy_tags: []
+    # List tags for your role here, one per line. A tag is a keyword that describes
+    # and categorizes the role. Users find roles by searching for tags. Be sure to
+    # remove the '[]' above, if you add tags to this list.
+    #
+    # NOTE: A tag is limited to a single word comprised of alphanumeric characters.
+    #       Maximum 20 tags per role.
+
+dependencies: []
+  # List your role dependencies here, one per line. Be sure to remove the '[]' above,
+  # if you add dependencies to this list.

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -3,7 +3,7 @@
 
 - name: '[Zabbix CRUD] Register password access'
   set_fact:
-    password_access: "{{ zabbix_crud_login_password is defined and zabbix_crud_login_password is string and zabbix_crud_login_password | length > 0 }}"
+    password_access: "{{ zabbix_api_http_password is defined and zabbix_api_http_password is string and zabbix_api_http_password | length > 0 }}"
 
 - name: '[Zabbix CRUD] Register token access'
   set_fact:

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -1,39 +1,44 @@
 ---
 # tasks file for zabbix_crud
 
-- name: '[Zabbix CRUD] Register password access'
-  set_fact:
-    password_access: "{{ zabbix_api_http_password is defined and zabbix_api_http_password is string and zabbix_api_http_password | length > 0 }}"
+- block:
 
-- name: '[Zabbix CRUD] Register token access'
-  set_fact:
-    token_access:
-      "{{ zabbix_api_auth_key is defined and zabbix_api_auth_key is string and zabbix_api_auth_key | length > 0 }}"
+  - name: '[Zabbix CRUD] Register password access'
+    set_fact:
+      password_access:
+        "{{ zabbix_api_http_password is defined and zabbix_api_http_password is string and zabbix_api_http_password | length > 0 }}"
 
-- name: '[Zabbix CRUD] Check conflict between token and password access configuration'
-  ansible.builtin.debug:
-    msg: "Token method and user/password method was detected, proceeding with token method."
-  when: password_access and token_access
+  - name: '[Zabbix CRUD] Register token access'
+    set_fact:
+      token_access:
+        "{{ zabbix_api_auth_key is defined and zabbix_api_auth_key is string and zabbix_api_auth_key | length > 0 }}"
 
-- name: '[Zabbix CRUD] Set common facts connection vía API'
-  ansible.builtin.set_fact:
-    ansible_network_os: community.zabbix.zabbix
-    ansible_connection: httpapi
-    ansible_httpapi_port: "{{ zabbix_api_server_port }}"
-    ansible_httpapi_use_ssl: "{{ zabbix_api_use_ssl }}"
-    ansible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
-    ansible_zabbix_url_path: "{{ zabbix_api_zabbix_url_path }}"
+  - name: '[Zabbix CRUD] Check conflict between token and password access configuration'
+    ansible.builtin.debug:
+      msg: "Token method and user/password method was detected, proceeding with token method."
+    when: password_access and token_access
 
-- name: '[Zabbix CRUD] Set password access'
-  ansible.builtin.set_fact:
-    ansible_user: "{{ zabbix_api_http_user }}"
-    ansible_httpapi_pass: "{{ zabbix_api_http_password }}"
-  when: password_access and not token_access
+  - name: '[Zabbix CRUD] Set common facts connection vía API'
+    ansible.builtin.set_fact:
+      ansible_network_os: community.zabbix.zabbix
+      ansible_connection: httpapi
+      ansible_httpapi_port: "{{ zabbix_api_server_port }}"
+      ansible_httpapi_use_ssl: "{{ zabbix_api_use_ssl }}"
+      ansible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
+      ansible_zabbix_url_path: "{{ zabbix_api_url_path }}"
 
-- name: '[Zabbix CRUD] Set token access'
-  ansible.builtin.set_fact:
-    ansible_zabbix_auth_key: "{{ zabbix_api_auth_key }}"
-  when: token_access or ( token_access and password_access )
+  - name: '[Zabbix CRUD] Set password access'
+    ansible.builtin.set_fact:
+      ansible_user: "{{ zabbix_api_http_user }}"
+      ansible_httpapi_pass: "{{ zabbix_api_http_password }}"
+    when: not token_access
+
+  - name: '[Zabbix CRUD] Set token access'
+    ansible.builtin.set_fact:
+      ansible_zabbix_auth_key: "{{ zabbix_api_auth_key }}"
+    when: token_access
+
+  tags: always
 
 - name: '[Zabbix CRUD] Wrap for zabbix_group - Create/Update/Delete Zabbix Host Groups'
   become: false
@@ -41,6 +46,7 @@
     host_groups: "{{ item.host_group }}"
     state: "{{ item.state | default(omit) }}"
   loop: "{{ zabbix_crud_host_groups }}"
+  tags: zabbix_crud_host_groups
 
 - name: '[Zabbix CRUD] Wrap for zabbix_mediatype module - Create/Update/Delete Zabbix media types'
   become: false
@@ -76,6 +82,7 @@
     webhook_script: "{{ item.webhook_script | default(omit) }}"
     webhook_timeout: "{{ item.webhook_timeout | default(omit) }}"
   loop: "{{ zabbix_crud_mediatypes }}"
+  tags: zabbix_crud_mediatypes
 
 - name: '[Zabbix CRUD] Wrap for zabbix_usergroup module - Create/Update/Delete Zabbix User Groups'
   become: false
@@ -90,7 +97,8 @@
     tag_filters: "{{ item.tag_filters | default(omit) }}"
     templategroup_rights: "{{ item.templategroup_rights | default(omit) }}"
     userdirectory: "{{ item.userdirectory | default(omit) }}"
-  loop: "{{ zabbix_crud_zabbix_usergroups }}"
+  loop: "{{ zabbix_crud_usergroups }}"
+  tags: zabbix_crud_usergroups
 
 - name: '[Zabbix CRUD] Wrap for zabbix_user_role module - Create/Update/Delete Zabbix User Roles'
   become: false
@@ -100,6 +108,7 @@
     type: "{{ item.type | default('User') }}"
     rules: "{{ item.rules | default(omit) }}"
   loop: "{{ zabbix_crud_user_roles }}"
+  tags: zabbix_crud_user_roles
 
 - name: '[Zabbix CRUD] Wrap for zabbix_user module - Create/Update/Delete Zabbix Users'
   become: false
@@ -122,8 +131,8 @@
     theme: "{{ item.theme | default(omit) }}"
     timezone: "{{ item.timezone | default(omit) }}"
     user_medias: "{{ item.user_medias | default(omit) }}"
-  # no_log: true
-  loop: "{{ zabbix_crud_zabbix_users }}"
+  no_log: true
+  loop: "{{  zabbix_crud_users }}"
   tags: zabbix_crud_users
 
 - name: '[Zabbix CRUD] Import provided JSON templates'
@@ -132,7 +141,7 @@
     template_json: "{{ lookup('file', item ) }}"
     state: present
   loop: "{{ zabbix_crud_json_templates }}"
-  tags: zabbix_crud_templates
+  tags: zabbix_crud_json_templates
 
 - name: '[Zabbix CRUD] Wrap for zabbix_host module - Create/Update/Delete Zabbix Hosts'
   become: false
@@ -161,8 +170,8 @@
     ipmi_password: "{{ item.ipmi_password | default(omit) }}"
     ipmi_privilege: "{{ item.ipmi_privilege | default(omit) }}"
     ipmi_username: "{{ item.ipmi_username | default(omit) }}"
-  loop: "{{ zabbix_crud_zabbix_hosts }}"
-  tags: zabbix_crud_zabbix_hosts
+  loop: "{{  zabbix_crud_hosts }}"
+  tags:  zabbix_crud_hosts
 
 - name: '[Zabbix CRUD] Wrap for zabbix_script module - Create/Update/Delete Zabbix Scripts'
   become: false
@@ -209,4 +218,3 @@
     status: "{{ item.status | default(omit) }}"
   loop: "{{ zabbix_crud_actions }}"
   tags: zabbix_crud_actions
-

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -19,15 +19,15 @@
   ansible.builtin.set_fact:
     ansible_network_os: community.zabbix.zabbix
     ansible_connection: httpapi
-    ansible_httpapi_port: "{{ zabbix_crud_httpapi_port }}"
-    ansible_httpapi_use_ssl: "{{ zabbix_crud_httpapi_use_ssl }}"
-    ansible_httpapi_validate_certs: "{{ zabbix_crud_httpapi_validate_certs }}"
+    ansible_httpapi_port: "{{ zabbix_api_server_port }}"
+    ansible_httpapi_use_ssl: "{{ zabbix_api_use_ssl }}"
+    ansible_httpapi_validate_certs: "{{ zabbix_api_validate_certs }}"
     ansible_zabbix_url_path: "{{ zabbix_api_zabbix_url_path }}"
 
 - name: '[Zabbix CRUD] Set password access'
   ansible.builtin.set_fact:
-    ansible_user: "{{ zabbix_crud_login_user }}"
-    ansible_httpapi_pass: "{{ zabbix_crud_login_password }}"
+    ansible_user: "{{ zabbix_api_http_user }}"
+    ansible_httpapi_pass: "{{ zabbix_api_http_password }}"
   when: password_access and not token_access
 
 - name: '[Zabbix CRUD] Set token access'

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -1,0 +1,213 @@
+---
+# tasks file for zabbix_crud
+
+- name: '[Zabbix CRUD] Register password access'
+  set_fact:
+    password_access: "{{ zabbix_crud_login_password is defined and zabbix_crud_login_password is string and zabbix_crud_login_password | length > 0 }}"
+
+- name: '[Zabbix CRUD] Register token access'
+  set_fact:
+    token_access:
+      "{{ zabbix_crud_auth_key is defined and zabbix_crud_auth_key is string and zabbix_crud_auth_key | length > 0 }}"
+
+- name: '[Zabbix CRUD] Check conflict between token and password access configuration'
+  ansible.builtin.assert:
+    that: ( password_access and token_access )
+    success_msg: were detect token method and user/password method, proceeding with token method.
+    quiet: no
+
+- name: '[Zabbix CRUD] Set common facts connection vía API'
+  ansible.builtin.set_fact:
+    ansible_network_os: community.zabbix.zabbix
+    ansible_connection: httpapi
+    ansible_httpapi_port: "{{ zabbix_crud_httpapi_port }}"
+    ansible_httpapi_use_ssl: "{{ zabbix_crud_httpapi_use_ssl }}"
+    ansible_httpapi_validate_certs: "{{ zabbix_crud_httpapi_validate_certs }}"
+    ansible_zabbix_url_path: "{{ zabbix_crud_zabbix_url_path }}"
+
+- name: '[Zabbix CRUD] Set password access'
+  ansible.builtin.set_fact:
+    ansible_user: "{{ zabbix_crud_login_user }}"
+    ansible_httpapi_pass: "{{ zabbix_crud_login_password }}"
+  when: password_access and not token_access
+
+- name: '[Zabbix CRUD] Set token access'
+  ansible.builtin.set_fact:
+    ansible_zabbix_auth_key: "{{ zabbix_crud_auth_key }}"
+  when: token_access or( token_access and password_access )
+
+- name: '[Zabbix CRUD] Wrap for zabbix_group - Create/Update/Delete Zabbix Host Groups'
+  become: false
+  community.zabbix.zabbix_group:
+    host_groups: "{{ item.host_group }}"
+    state: "{{ item.state | default(omit) }}"
+  loop: "{{ zabbix_crud_host_groups }}"
+
+- name: '[Zabbix CRUD] Wrap for zabbix_mediatype module - Create/Update/Delete Zabbix media types'
+  become: false
+  community.zabbix.zabbix_mediatype:
+    name: "{{ item.name }}"
+    type: "{{ item.type }}"
+    attempt_interval: "{{ item.attempt_interval | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    event_menu: "{{ item.event_menu | default(omit) }}"
+    event_menu_name: "{{ item.event_menu_name | default(omit) }}"
+    event_menu_url: "{{ item.event_menu_url | default(omit) }}"
+    gsm_modem: "{{ item.gsm_modem | default(omit) }}"
+    max_attempts: "{{ item.max_attempts | default(omit) }}"
+    max_sessions: "{{ item.max_sessions | default(omit) }}"
+    message_templates: "{{ item.message_templates | default(omit) }}"
+    message_text_limit: "{{ item.message_text_limit | default(omit) }}"
+    password:  "{{ item.password | default(omit) }}"
+    process_tags: "{{ item.process_tags | default(omit) }}"
+    script_name: "{{ item.script_name | default(omit) }}"
+    script_params: "{{ item.script_params | default(omit) }}"
+    smtp_authentication:  "{{ item.smtp_authentication | default(omit) }}"
+    smtp_email: "{{ item.smtp_email | default(omit) }}"
+    smtp_helo: "{{ item.smtp_helo | default(omit) }}"
+    smtp_security: "{{ item.smtp_security | default(omit) }}"
+    smtp_server: "{{ item.smtp_server | default(omit) }}"
+    smtp_server_port: "{{ item.smtp_server_port | default(omit) }}"
+    smtp_verify_host: "{{ item.smtp_verify_host | default(omit) }}"
+    smtp_verify_peer: "{{ item.smtp_verify_peer | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    status: "{{ item.status | default(omit) }}"
+    username:  "{{ item.username | default(omit) }}"
+    webhook_params: "{{ item.webhook_params | default(omit) }}"
+    webhook_script: "{{ item.webhook_script | default(omit) }}"
+    webhook_timeout: "{{ item.webhook_timeout | default(omit) }}"
+  loop: "{{ zabbix_crud_mediatypes }}"
+
+- name: '[Zabbix CRUD] Wrap for zabbix_usergroup module - Create/Update/Delete Zabbix User Groups'
+  become: false
+  community.zabbix.zabbix_usergroup:
+    name: "{{ item.name }}"
+    debug_mode: "{{ item.debug_mode | default(omit) }}"
+    gui_access: "{{ item.gui_access | default(omit) }}"
+    hostgroup_rights: "{{ item.hostgroup_rights | default(omit) }}"
+    rights: "{{ item.rights | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    status: "{{ item.status | default(omit) }}"
+    tag_filters: "{{ item.tag_filters | default(omit) }}"
+    templategroup_rights: "{{ item.templategroup_rights | default(omit) }}"
+    userdirectory: "{{ item.userdirectory | default(omit) }}"
+  loop: "{{ zabbix_crud_zabbix_usergroups }}"
+
+- name: '[Zabbix CRUD] Wrap for zabbix_user_role module - Create/Update/Delete Zabbix User Roles'
+  become: false
+  community.zabbix.zabbix_user_role:
+    name: "{{ item.name }}"
+    state: "{{ item.state | default('present') }}"
+    type: "{{ item.type | default('User') }}"
+    rules: "{{ item.rules | default(omit) }}"
+  loop: "{{ zabbix_crud_user_roles }}"
+
+- name: '[Zabbix CRUD] Wrap for zabbix_user module - Create/Update/Delete Zabbix Users'
+  become: false
+  community.zabbix.zabbix_user:
+    username: "{{ item.username }}"
+    usrgrps: "{{ item.usrgrps }}"
+    passwd: "{{ item.passwd }}"
+    after_login_url: "{{ item.after_login_url | default(omit) }}"
+    autologin: "{{ item.autologin | default(omit) }}"
+    autologout: "{{ item.autologout | default(omit) }}"
+    current_password: "{{ item.current_password | default(omit) }}"
+    lang: "{{ item.lang | default(omit) }}"
+    name: "{{ item.name | default(omit) }}"
+    override_passwd: "{{ item.override_passwd | default(omit) }}"
+    refresh: "{{ item.refresh | default(omit) }}"
+    role_name: "{{ item.role_name | default(omit) }}"
+    rows_per_page: "{{ item.rows_per_page | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    surname: "{{ item.surname | default(omit) }}"
+    theme: "{{ item.theme | default(omit) }}"
+    timezone: "{{ item.timezone | default(omit) }}"
+    user_medias: "{{ item.user_medias | default(omit) }}"
+  # no_log: true
+  loop: "{{ zabbix_crud_zabbix_users }}"
+  tags: zabbix_crud_users
+
+- name: '[Zabbix CRUD] Import provided JSON templates'
+  become: false
+  community.zabbix.zabbix_template:
+    template_json: "{{ lookup('file', item ) }}"
+    state: present
+  loop: "{{ zabbix_crud_json_templates }}"
+  tags: zabbix_crud_templates
+
+- name: '[Zabbix CRUD] Wrap for zabbix_host module - Create/Update/Delete Zabbix Hosts'
+  become: false
+  community.zabbix.zabbix_host:
+    host_name: "{{ item.host_name }}"
+    visible_name: "{{ item.visible_name | default(omit) }}"
+    ca_cert: "{{ item.ca_cert | default(omit) }}"
+    tls_accept: "{{ item.tls_accept | default(omit) }}"
+    tls_connect: "{{ item.tls_connect | default(omit) }}"
+    tls_psk: "{{ item.tls_psk | default(omit) }}"
+    tls_psk_identity: "{{ item.tls_psk_identity | default(omit) }}"
+    tls_subject: "{{ item.tls_subject | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    host_groups: "{{ item.host_groups }}"
+    link_templates: "{{ item.link_templates }}"
+    status: "{{ item.status | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    interfaces: "{{ item.interfaces | default(omit) }}"
+    proxy: "{{ item.proxy | default(omit) }}"
+    macros: "{{ item.macros | default(omit) }}"
+    tags: "{{ item.tags | default(omit) }}"
+    force: "{{ item.force | default(omit) }}"
+    inventory_mode: "{{ item.inventory_mode | default(omit) }}"
+    inventory_zabbix: "{{ item.inventory_zabbix | default(omit) }}"
+    ipmi_authtype: "{{ item.ipmi_authtype | default(omit) }}"
+    ipmi_password: "{{ item.ipmi_password | default(omit) }}"
+    ipmi_privilege: "{{ item.ipmi_privilege | default(omit) }}"
+    ipmi_username: "{{ item.ipmi_username | default(omit) }}"
+  loop: "{{ zabbix_crud_zabbix_hosts }}"
+  tags: zabbix_crud_zabbix_hosts
+
+- name: '[Zabbix CRUD] Wrap for zabbix_script module - Create/Update/Delete Zabbix Scripts'
+  become: false
+  community.zabbix.zabbix_script:
+    name: "{{ item.name }}"
+    command: "{{ item.command }}"
+    script_type: "{{ item.script_type }}"
+    authtype: "{{ item.authtype | default(omit) }}"
+    confirmation: "{{ item.confirmation | default(omit) }}"
+    description: "{{ item.description | default(omit) }}"
+    execute_on: "{{ item.execute_on | default(omit) }}"
+    host_access: "{{ item.host_access | default(omit) }}"
+    host_group: "{{ item.host_group | default(omit) }}"
+    menu_path: "{{ item.menu_path | default(omit) }}"
+    parameters: "{{ item.parameters | default(omit) }}"
+    password: "{{ item.password | default(omit) }}"
+    port: "{{ item.port | default(omit) }}"
+    privatekey: "{{ item.privatekey | default(omit) }}"
+    publickey: "{{ item.publickey | default(omit) }}"
+    scope: "{{ item.scope | default(omit) }}"
+    script_timeout: "{{ item.script_timeout | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    user_group: "{{ item.user_group | default(omit) }}"
+    username: "{{ item.username | default(omit) }}"
+  loop: "{{ zabbix_crud_scripts }}"
+  tags: zabbix_crud_scripts
+
+- name: '[Zabbix CRUD] Wrap for zabbix_action module - Create/Update/Delete Zabbix Actions'
+  become: false
+  community.zabbix.zabbix_action:
+    name: "{{ item.name }}"
+    acknowledge_operations: "{{ item.acknowledge_operations | default(omit) }}"
+    conditions: "{{ item.conditions | default(omit) }}"
+    esc_period: "{{ item.esc_period | default(omit) }}"
+    eval_type: "{{ item.eval_type | default(omit) }}"
+    event_source: "{{ item.event_source | default('trigger') }}"
+    formula: "{{ item.formula | default(omit) }}"
+    notify_if_canceled: "{{ item.notify_if_canceled | default(omit) }}"
+    operations: "{{ item.operations | default(omit) }}"
+    pause_in_maintenance: "{{ item.pause_in_maintenance | default(omit) }}"
+    pause_symptoms: "{{ item.pause_symptoms | default(omit) }}"
+    recovery_operations: "{{ item.recovery_operations | default(omit) }}"
+    state: "{{ item.state | default(omit) }}"
+    status: "{{ item.status | default(omit) }}"
+  loop: "{{ zabbix_crud_actions }}"
+  tags: zabbix_crud_actions
+

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -147,7 +147,7 @@
     tls_subject: "{{ item.tls_subject | default(omit) }}"
     description: "{{ item.description | default(omit) }}"
     host_groups: "{{ item.host_groups }}"
-    link_templates: "{{ item.link_templates }}"
+    link_templates: "{{ item.link_templates | default(omit) }}"
     status: "{{ item.status | default(omit) }}"
     state: "{{ item.state | default(omit) }}"
     interfaces: "{{ item.interfaces | default(omit) }}"

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -8,13 +8,12 @@
 - name: '[Zabbix CRUD] Register token access'
   set_fact:
     token_access:
-      "{{ zabbix_crud_auth_key is defined and zabbix_crud_auth_key is string and zabbix_crud_auth_key | length > 0 }}"
+      "{{ zabbix_api_auth_key is defined and zabbix_api_auth_key is string and zabbix_api_auth_key | length > 0 }}"
 
 - name: '[Zabbix CRUD] Check conflict between token and password access configuration'
-  ansible.builtin.assert:
-    that: ( password_access and token_access )
-    success_msg: were detect token method and user/password method, proceeding with token method.
-    quiet: no
+  ansible.builtin.debug:
+    msg: "Token method and user/password method was detected, proceeding with token method."
+  when: password_access and token_access
 
 - name: '[Zabbix CRUD] Set common facts connection vía API'
   ansible.builtin.set_fact:
@@ -23,7 +22,7 @@
     ansible_httpapi_port: "{{ zabbix_crud_httpapi_port }}"
     ansible_httpapi_use_ssl: "{{ zabbix_crud_httpapi_use_ssl }}"
     ansible_httpapi_validate_certs: "{{ zabbix_crud_httpapi_validate_certs }}"
-    ansible_zabbix_url_path: "{{ zabbix_crud_zabbix_url_path }}"
+    ansible_zabbix_url_path: "{{ zabbix_api_zabbix_url_path }}"
 
 - name: '[Zabbix CRUD] Set password access'
   ansible.builtin.set_fact:
@@ -33,8 +32,8 @@
 
 - name: '[Zabbix CRUD] Set token access'
   ansible.builtin.set_fact:
-    ansible_zabbix_auth_key: "{{ zabbix_crud_auth_key }}"
-  when: token_access or( token_access and password_access )
+    ansible_zabbix_auth_key: "{{ zabbix_api_auth_key }}"
+  when: token_access or ( token_access and password_access )
 
 - name: '[Zabbix CRUD] Wrap for zabbix_group - Create/Update/Delete Zabbix Host Groups'
   become: false

--- a/roles/zabbix_crud/vars/main.yml
+++ b/roles/zabbix_crud/vars/main.yml
@@ -1,0 +1,2 @@
+---
+# vars file for zabbix_crud


### PR DESCRIPTION
Here is mi proposal to be part of zabbix.community code. Its about a new role what performs several CRUD actions vía Zabbix API. Takes most common modules, wrap in to variables and configure it!

On README file you find more info.

I'm propose these changes in LibreDevOps first to minimal review and merge. @santiagomr: can you do this? On the second step, we'll PR to upstream.

Thanks in advance!