### PR TITLE
Add valid versions for trixie

### DIFF
--- a/roles/zabbix_javagateway/vars/Debian.yml
+++ b/roles/zabbix_javagateway/vars/Debian.yml
@@ -1,5 +1,8 @@
 zabbix_valid_javagateway_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_proxy/vars/Debian.yml
+++ b/roles/zabbix_proxy/vars/Debian.yml
@@ -1,5 +1,9 @@
 zabbix_valid_proxy_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
+    - 6.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_server/vars/Debian.yml
+++ b/roles/zabbix_server/vars/Debian.yml
@@ -7,6 +7,9 @@ mysql_create_dir: ""
 
 zabbix_valid_server_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2

--- a/roles/zabbix_web/vars/Debian.yml
+++ b/roles/zabbix_web/vars/Debian.yml
@@ -23,6 +23,9 @@ _nginx_tls_dhparam: /etc/ssl/private/dhparams.pem
 
 zabbix_valid_web_versions:
   # Debian
+  "13":
+    - 7.4
+    - 7.0
   "12":
     - 7.4
     - 7.2


### PR DESCRIPTION
This PR adds configuration needed to use the roles on Debian 13 (not yet accepted upstream).