### PR TITLE
change default variables to connect via api

### DIFF
--- a/docs/ZABBIX_CRUD_ROLE.md
+++ b/docs/ZABBIX_CRUD_ROLE.md
@@ -31,8 +31,10 @@ See `defaults/main.yml` for more details.
 `zabbix_api_use_ssl`: use SSL for httpapi connection, `false` by default.
 `zabbix_api_validate_certs`: validate certs for httpapi connection, `false` by default.
 `zabbix_api_zabbix_url_path`: path to web directory or alias, `zabbix` by default.
-`zabbix_api_http_user`: login user, `Admin` by default.
-`zabbix_api_http_password`: login password, `zabbix` by default.
+`zabbix_api_login_user`: Username of user which has API access.
+`zabbix_api_login_pass`: Password for the user which has API access.
+`zabbix_api_http_user`: The http user to access zabbix url with Basic Auth (if your Zabbix is behind a proxy with HTTP Basic Auth).
+`zabbix_api_http_password`: The http password to access zabbix url with Basic Auth (if your Zabbix is behind a proxy with HTTP Basic Auth).
 `zabbix_api_auth_key`: API token for access. Not set by default.
 
 # Example Playbook

--- a/roles/zabbix_crud/defaults/main.yml
+++ b/roles/zabbix_crud/defaults/main.yml
@@ -6,8 +6,8 @@ zabbix_api_server_port: 80
 zabbix_api_url_path: 'zabbix'
 zabbix_api_use_ssl: false
 zabbix_api_validate_certs: false
-zabbix_api_http_user: Admin
-zabbix_api_http_password: !unsafe zabbix
+zabbix_api_login_user: Admin
+zabbix_api_login_pass: !unsafe zabbix
 # zabbix_api_auth_key: a_previously_generated_token
 
 

--- a/roles/zabbix_crud/tasks/main.yml
+++ b/roles/zabbix_crud/tasks/main.yml
@@ -29,8 +29,12 @@
 
   - name: '[Zabbix CRUD] Set password access'
     ansible.builtin.set_fact:
-      ansible_user: "{{ zabbix_api_http_user }}"
-      ansible_httpapi_pass: "{{ zabbix_api_http_password }}"
+      # --- Basic Auth (Begin) ---
+      http_login_user: "{{ zabbix_api_http_user | default(-42) }}"
+      http_login_password: "{{ zabbix_api_http_password | default(-42) }}"
+      # --- Basic Auth (End) ---
+      ansible_user: "{{ zabbix_api_login_user }}"
+      ansible_httpapi_pass: "{{ zabbix_api_login_pass }}"
     when: not token_access
 
   - name: '[Zabbix CRUD] Set token access'


### PR DESCRIPTION
Just like in the `zabbix_agent` and `zabbix_proxy roles`, the variables `http_login_user` and `http_login_password `are no longer used as defaults.
These variables are meant to be used only when accessing through a URL that requires Basic Auth.

Instead, the variables `zabbix_api_login_user` and `zabbix_api_login_pass` are now used.

To maintain consistency with the original collection, I believe it’s necessary to follow the same approach here.


This PR was already accepted in [another repo](https://github.com/UdelaRInterior/libredevops.zabbix/pull/1).